### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # `gcr.io/paketo-buildpacks/encrypt-at-rest`
-The Paketo Encrypt At Rest Buildpack is a Cloud Native Buildpack that AES encrypts an application layer and then decrypts it at launch time.
+The Paketo Buildpack for Encrypt At Rest is a Cloud Native Buildpack that AES encrypts an application layer and then decrypts it at launch time.
 
 ## Behavior
 This buildpack will participate any of the following conditions are met

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/encrypt-at-rest"
   id = "paketo-buildpacks/encrypt-at-rest"
   keywords = ["AES", "encrypt-at-rest"]
-  name = "Paketo Encrypt-at-Rest Buildpack"
+  name = "Paketo Buildpack for Encrypt-at-Rest"
   version = "{{.version}}"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/vnd.syft+json"]
 


### PR DESCRIPTION
Renames 'Paketo Encrypt-at-Rest Buildpack' to 'Paketo Buildpack for Encrypt-at-Rest'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
